### PR TITLE
Allow using 'x-forwarded-for' as source ip addr

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ type MaxmindGeolocation struct {
 	DenyASN []string `json:"deny_asn"`
 
 	// Use x-forwarded-ip as remote ip
-	Forwarded bool `json:"forwarded,omitempty"`
+	Forwarded bool `json:"forwarded_as_sources_ip,omitempty"`
 
 	dbInst *maxminddb.Reader
 	logger *zap.Logger


### PR DESCRIPTION
Now it can use 'x-forwarded-for' as the real source IP address, for some situations like the http server behind the Cloudflare

Enable it with `forwarded_as_sources_ip`

Test with Cloudflare CDN service:

- Without `forwarded_as_sources_ip`, the module didn't detect my real source IP.
![image](https://github.com/porech/caddy-maxmind-geolocation/assets/30458572/97c80859-988d-410a-a7e4-f9ad4fdc7d54)

- With `forwarded_as_sources_ip`, the module now can detect my real source IP.
![image](https://github.com/porech/caddy-maxmind-geolocation/assets/30458572/32c58538-d908-4f59-bea8-387b5d504b92)
\
![image](https://github.com/porech/caddy-maxmind-geolocation/assets/30458572/c584e2bd-d65a-4971-b67f-e720016061b0)

